### PR TITLE
Arp explode fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ BINARY=routed-plugin
 
 BUILD = `git rev-parse HEAD`
 BUILD_TIME=`date +%FT%T%z`
+GWIP := $(shell ifconfig eth0 | awk -F"[: ]+" '/inet addr:/ {print $$4}')
 
 LDFLAGS=-ldflags "-X main.Build=${BUILD} -X main.BuildTime=${BUILD_TIME}"
 
@@ -27,7 +28,7 @@ docker-clean:
 	-@docker rmi $(docker images | grep "^<none>" | awk '{print $3}') > /dev/null 2>&1
 
 docker-run: docker-build
-	docker run -ti --privileged --net=host --rm -v /run/docker/plugins:/run/docker/plugins ${IMAGETAG} --debug
+	docker run -ti --privileged --net=host --rm -v /run/docker/plugins:/run/docker/plugins ${IMAGETAG} --gateway ${GWIP} --debug
 
 .DEFAULT_GOAL: build
 .PHONY: clean, docker-clean

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BINARY=routed-plugin
 
 BUILD = `git rev-parse HEAD`
 BUILD_TIME=`date +%FT%T%z`
-GWIP := $(shell ifconfig eth0 | awk -F"[: ]+" '/inet addr:/ {print $$4}')
+GWIP := $(shell ip route get 8.8.8.8 | head --lines 1 | awk '{print $$7}')
 
 LDFLAGS=-ldflags "-X main.Build=${BUILD} -X main.BuildTime=${BUILD_TIME}"
 
@@ -28,7 +28,7 @@ docker-clean:
 	-@docker rmi $(docker images | grep "^<none>" | awk '{print $3}') > /dev/null 2>&1
 
 docker-run: docker-build
-	docker run -ti --privileged --net=host --rm -v /run/docker/plugins:/run/docker/plugins ${IMAGETAG} --gateway ${GWIP} --debug
+	docker run -ti --privileged --net=host --rm -v /run/docker/plugins:/run/docker/plugins ${IMAGETAG} --gateway ${GWIP} --debug --mtu 9000
 
 .DEFAULT_GOAL: build
 .PHONY: clean, docker-clean

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ driver running in the host. The <host-ip> argument should be the IP address that
 corresponds to the interface in the host that you wish to use as default route.
 
 ```
-docker run -ti --privileged --net=host --rm -v /run/docker/plugins:/run/docker/plugins test/routed-plugin --gateway <host-ip> --debug
+docker run -ti --privileged --net=host --rm -v /run/docker/plugins:/run/docker/plugins test/routed-plugin --gateway <host-ip> --debug --mtu 9000
 ```
 
 Then you will need to register a routed network. Note that it uses the Ipam routed driver.

--- a/README.md
+++ b/README.md
@@ -38,16 +38,17 @@ interface eth1
 ```
 
 To launch a container using the routed mode, you first need to have the routed
-driver running in the host.
+driver running in the host. The <host-ip> argument should be the IP address that
+corresponds to the interface in the host that you wish to use as default route.
 
 ```
-docker run -ti --privileged --net=host --rm -v /run/docker/plugins:/run/docker/plugins test/routed-plugin --debug
+docker run -ti --privileged --net=host --rm -v /run/docker/plugins:/run/docker/plugins test/routed-plugin --gateway <host-ip> --debug
 ```
 
 Then you will need to register a routed network. Note that it uses the Ipam routed driver.
 
 ```
-docker network create --internal --driver=net-routed --ipam-driver=ipam-routed --subnet 10.46.1.0/16 --gateway 10.46.1.1 mine
+docker network create --internal --driver=net-routed --ipam-driver=ipam-routed --subnet 10.46.1.0/16 mine
 ```
 
 Finally, you can run a container attached to the routed network you created previously.
@@ -55,7 +56,7 @@ You will need to specify the ip address to assign to the container endpoint usin
 --ip label.  
 
 ```
-docker run -ti --net=mine --ip 10.46.1.7 debian:jessie sh
+docker run -ti --net=mine --ip 10.46.1.7 alpine sh
 ```
 
 ## Contributing
@@ -80,7 +81,7 @@ docker run -ti --net=mine --ip 10.46.1.7 debian:jessie sh
   ```
 
 3. Initialize your vagrant VM. (Note that the Vagrantfile includes instructions
-to configure ip4 forwarding, proxy arp and iptables chains on VM provision.
+to configure ip4 forwarding and iptables chains on VM provision.
 If this script is modified in the Vagrantfile, the VM will need to be
 re-provisioned using ```vagrant up --provision```)
 
@@ -158,7 +159,7 @@ re-provisioned using ```vagrant up --provision```)
   ```
   vagrant ssh
   docker network create --internal --driver=net-routed --ipam-driver=ipam-routed --subnet 10.46.0.0/16  mine
-  docker run -ti --net=mine --ip 10.46.1.7 debian:jessie sh
+  docker run -ti --net=mine --ip 10.46.1.7 alpine sh
   ```
 
 ### Debugging with Delve

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,13 +2,9 @@
 # vi: set ft=ruby :
 
 # Enable routing container traffic through the VM, equivalent to:
-#sudo sysctl -w net.ipv4.conf.default.proxy_arp=1
-#sudo sysctl -w net.ipv4.conf.eth0.proxy_arp=1
 #sudo sysctl -w net.ipv4.ip_forward=1
 # Create iptables chains and make them persistent
 $script = <<SCRIPT
-sudo sh -c 'echo "net.ipv4.conf.default.proxy_arp=1" >> /etc/sysctl.conf'
-sudo sh -c 'echo "net.ipv4.conf.eth0.proxy_arp=1" >> /etc/sysctl.conf'
 sudo sh -c 'echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf'
 sudo service procps start
 

--- a/routed/ipam-driver.go
+++ b/routed/ipam-driver.go
@@ -7,6 +7,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	ipamApi "github.com/docker/go-plugins-helpers/ipam"
+	"github.com/docker/libnetwork/netlabel"
 	"github.com/vishvananda/netlink"
 )
 
@@ -84,7 +85,7 @@ func (d *IpamDriver) RequestPool(r *ipamApi.RequestPoolRequest) (*ipamApi.Reques
 	res := &ipamApi.RequestPoolResponse{
 		PoolID: id,
 		Pool:   cidr,
-		Data:   map[string]string{"com.docker.network.gateway": gateway},
+		Data:   map[string]string{netlabel.Gateway: gateway},
 	}
 
 	log.Infof("RequestPool: responded with %+v", res)
@@ -103,7 +104,7 @@ func (d *IpamDriver) ReleasePool(r *ipamApi.ReleasePoolRequest) error {
 func (d *IpamDriver) RequestAddress(r *ipamApi.RequestAddressRequest) (*ipamApi.RequestAddressResponse, error) {
 	log.Debugf("RequestAddress: request %+v", r)
 
-	if r.Options["RequestAddressType"] == "com.docker.network.gateway" {
+	if r.Options["RequestAddressType"] == netlabel.Gateway {
 		return nil, fmt.Errorf("RequestAddress: can't change gateway")
 	}
 

--- a/routed/net-driver.go
+++ b/routed/net-driver.go
@@ -44,13 +44,8 @@ type NetDriver struct {
 	network *routedNetwork
 }
 
-func NewNetDriver(version string) (*NetDriver, error) {
+func NewNetDriver(version string, gateway string) (*NetDriver, error) {
 	log.Debugf("NewNetDriver: Initializing routed driver version %+v", version)
-
-	d := &NetDriver{
-		version: version,
-		mtu:     defaultMtu,
-	}
 
 	links, err := netlink.LinkList()
 	if err != nil {
@@ -65,16 +60,13 @@ func NewNetDriver(version string) (*NetDriver, error) {
 			} else {
 				log.Infof("NewNetDriver: veth cleaned up: %s", lnk.Attrs().Name)
 			}
-		} else if lnk.Attrs().Name == defaultGwIface {
-
-			addrs, err := netlink.AddrList(lnk, netlink.FAMILY_V4)
-			if err != nil {
-				log.Errorf("NewNetDriver: Can't get list of ipv4 addresses: %s", err)
-				return nil, err
-			}
-
-			d.gateway = addrs[0].IP.String()
 		}
+	}
+
+	d := &NetDriver{
+		version: version,
+		mtu:     defaultMtu,
+		gateway: gateway,
 	}
 
 	return d, nil

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,6 +3,18 @@
 	"ignore": "test",
 	"package": [
 		{
+			"checksumSHA1": "23FJUX+AInYeEM2hoUMvYZtXZd4=",
+			"path": "github.com/Azure/go-ansiterm",
+			"revision": "fa152c58bc15761d0200cb75fe958b89a9d4888e",
+			"revisionTime": "2016-06-22T17:32:16Z"
+		},
+		{
+			"checksumSHA1": "jBimnggjIiFUjaImNoJhSVLtdzw=",
+			"path": "github.com/Azure/go-ansiterm/winterm",
+			"revision": "fa152c58bc15761d0200cb75fe958b89a9d4888e",
+			"revisionTime": "2016-06-22T17:32:16Z"
+		},
+		{
 			"checksumSHA1": "DWPL08pD/SQ2GzLfoR7ZXnjj7Sw=",
 			"path": "github.com/Sirupsen/logrus",
 			"revision": "4b6ea7319e214d98c938f12692336f7ca9348d6b",
@@ -13,6 +25,12 @@
 			"path": "github.com/coreos/go-systemd/activation",
 			"revision": "bfdc81d0d7e0fb19447b08571f63b774495251ce",
 			"revisionTime": "2016-08-15T18:53:29Z"
+		},
+		{
+			"checksumSHA1": "qEA0NNEkJR39n6HNq1xi5AhXU54=",
+			"path": "github.com/coreos/go-systemd/dbus",
+			"revision": "43e4800a6165b4e02bb2a36673c54b230d6f7b26",
+			"revisionTime": "2016-08-26T10:46:00Z"
 		},
 		{
 			"checksumSHA1": "e8qgBHxXbij3RVspqrkeBzMZ564=",
@@ -39,10 +57,40 @@
 			"revisionTime": "2016-08-15T20:02:59Z"
 		},
 		{
+			"checksumSHA1": "KcxHd9tdO+5C/G08iehlwZOzNCE=",
+			"path": "github.com/docker/docker/pkg/mount",
+			"revision": "bb1d70da9ad5804794b7aea77abe59fb9e3ac196",
+			"revisionTime": "2016-08-30T14:37:20Z"
+		},
+		{
 			"checksumSHA1": "B37RZZTMQB7Z6uS6PoIysI78Y+4=",
 			"path": "github.com/docker/docker/pkg/reexec",
 			"revision": "90be7a591de1f30332827a003edc39065fb8e4a7",
 			"revisionTime": "2016-08-15T20:02:59Z"
+		},
+		{
+			"checksumSHA1": "I6XL+pDmC4XSWDvI7d14ZVDsY9c=",
+			"path": "github.com/docker/docker/pkg/symlink",
+			"revision": "bb1d70da9ad5804794b7aea77abe59fb9e3ac196",
+			"revisionTime": "2016-08-30T14:37:20Z"
+		},
+		{
+			"checksumSHA1": "5OnCyro0Cu1PJAUc6bGBYneR3QQ=",
+			"path": "github.com/docker/docker/pkg/system",
+			"revision": "bb1d70da9ad5804794b7aea77abe59fb9e3ac196",
+			"revisionTime": "2016-08-30T14:37:20Z"
+		},
+		{
+			"checksumSHA1": "E+nAUmxUmGVf9py6HDVjs3LOBUU=",
+			"path": "github.com/docker/docker/pkg/term",
+			"revision": "bb1d70da9ad5804794b7aea77abe59fb9e3ac196",
+			"revisionTime": "2016-08-30T14:37:20Z"
+		},
+		{
+			"checksumSHA1": "k1RJrQuAMExp5VUDOXlnLBN47vE=",
+			"path": "github.com/docker/docker/pkg/term/windows",
+			"revision": "bb1d70da9ad5804794b7aea77abe59fb9e3ac196",
+			"revisionTime": "2016-08-30T14:37:20Z"
 		},
 		{
 			"checksumSHA1": "3sQ35fcqLJRnyTqaZn8Zb9l97uk=",
@@ -67,6 +115,12 @@
 			"path": "github.com/docker/go-plugins-helpers/sdk",
 			"revision": "f3a3876798ee4f63bee3e7ee8911a2c27e7710b9",
 			"revisionTime": "2016-08-02T13:54:27Z"
+		},
+		{
+			"checksumSHA1": "KbWP8VsU9gVoZm9pCqe79AkfDmk=",
+			"path": "github.com/docker/go-units",
+			"revision": "2c1805a1c750c4ea749899f49221e1d5f3e5ce42",
+			"revisionTime": "2016-08-28T18:08:47Z"
 		},
 		{
 			"checksumSHA1": "bOO/7ugQ7KwqdU5ftNAAXKk1GRI=",
@@ -99,16 +153,34 @@
 			"revisionTime": "2016-08-15T22:03:51Z"
 		},
 		{
+			"checksumSHA1": "MlDcWGpA+InBFkp0xgdjyKfQ58o=",
+			"path": "github.com/docker/libnetwork/iptables",
+			"revision": "11e47da758297b2f87c5d6299e3d4e0f9704d11a",
+			"revisionTime": "2016-08-26T05:56:55Z"
+		},
+		{
 			"checksumSHA1": "zxJM4MD4vqTR2HZWrpUZFQzIbUY=",
 			"path": "github.com/docker/libnetwork/netlabel",
 			"revision": "e40405234233432f2ad8bfa1b94be46687e945d9",
 			"revisionTime": "2016-08-15T22:03:51Z"
 		},
 		{
+			"checksumSHA1": "MRyv3BM8HRN7OIQyHLJmNVjAyF4=",
+			"path": "github.com/docker/libnetwork/netutils",
+			"revision": "11e47da758297b2f87c5d6299e3d4e0f9704d11a",
+			"revisionTime": "2016-08-26T05:56:55Z"
+		},
+		{
 			"checksumSHA1": "rOxzVbONKQDmMsjvUpvgy2GUz3g=",
 			"path": "github.com/docker/libnetwork/ns",
 			"revision": "e40405234233432f2ad8bfa1b94be46687e945d9",
 			"revisionTime": "2016-08-15T22:03:51Z"
+		},
+		{
+			"checksumSHA1": "Uq3rNBWbKxNwVin7o6kP8/M2sHU=",
+			"path": "github.com/docker/libnetwork/osl",
+			"revision": "11e47da758297b2f87c5d6299e3d4e0f9704d11a",
+			"revisionTime": "2016-08-26T05:56:55Z"
 		},
 		{
 			"checksumSHA1": "cYfP6Rxw/qlqj0LLMu6QoP2PYe8=",
@@ -135,6 +207,144 @@
 			"revisionTime": "2016-07-27T17:45:41Z"
 		},
 		{
+			"checksumSHA1": "sZSeW3Dc6lUqm1CzMUdu3poimoA=",
+			"path": "github.com/golang/protobuf/proto",
+			"revision": "1f49d83d9aa00e6ce4fc8258c71cc7786aec968a",
+			"revisionTime": "2016-08-24T20:12:15Z"
+		},
+		{
+			"checksumSHA1": "uH4q8SFedJRaTvcu4U5tSdk2yD0=",
+			"path": "github.com/opencontainers/runc",
+			"revision": "189a2ab2f7acc59043e457cea25b58f631443f08",
+			"revisionTime": "2016-08-27T03:18:55Z"
+		},
+		{
+			"checksumSHA1": "LS7QkIZLYW/GbRnWgx5RcE3Va4c=",
+			"path": "github.com/opencontainers/runc/libcontainer",
+			"revision": "189a2ab2f7acc59043e457cea25b58f631443f08",
+			"revisionTime": "2016-08-27T03:18:55Z"
+		},
+		{
+			"checksumSHA1": "vR7lceP8RDWLttyU692t3aYkdB4=",
+			"path": "github.com/opencontainers/runc/libcontainer/apparmor",
+			"revision": "189a2ab2f7acc59043e457cea25b58f631443f08",
+			"revisionTime": "2016-08-27T03:18:55Z"
+		},
+		{
+			"checksumSHA1": "rZ+R9aUXBsiKbG/ghsJgroBTCZk=",
+			"path": "github.com/opencontainers/runc/libcontainer/cgroups",
+			"revision": "189a2ab2f7acc59043e457cea25b58f631443f08",
+			"revisionTime": "2016-08-27T03:18:55Z"
+		},
+		{
+			"checksumSHA1": "y5pwrUqnsL6liBus5EwyGA5ZiJ4=",
+			"path": "github.com/opencontainers/runc/libcontainer/cgroups/fs",
+			"revision": "189a2ab2f7acc59043e457cea25b58f631443f08",
+			"revisionTime": "2016-08-27T03:18:55Z"
+		},
+		{
+			"checksumSHA1": "/AqywL+FPgEvZeoKXEPMmszP/pE=",
+			"path": "github.com/opencontainers/runc/libcontainer/cgroups/systemd",
+			"revision": "189a2ab2f7acc59043e457cea25b58f631443f08",
+			"revisionTime": "2016-08-27T03:18:55Z"
+		},
+		{
+			"checksumSHA1": "X9to1OH87tOEhSLzyn3yzOADBXw=",
+			"path": "github.com/opencontainers/runc/libcontainer/configs",
+			"revision": "189a2ab2f7acc59043e457cea25b58f631443f08",
+			"revisionTime": "2016-08-27T03:18:55Z"
+		},
+		{
+			"checksumSHA1": "325cl8YxMdl8YKMz3gvm8PuUSZQ=",
+			"path": "github.com/opencontainers/runc/libcontainer/configs/validate",
+			"revision": "189a2ab2f7acc59043e457cea25b58f631443f08",
+			"revisionTime": "2016-08-27T03:18:55Z"
+		},
+		{
+			"checksumSHA1": "Xz86hvn4IsUU9R/B6NsqVMsman0=",
+			"path": "github.com/opencontainers/runc/libcontainer/criurpc",
+			"revision": "189a2ab2f7acc59043e457cea25b58f631443f08",
+			"revisionTime": "2016-08-27T03:18:55Z"
+		},
+		{
+			"checksumSHA1": "Xy/KIDXg8pkPbXYh4lj7yDCgn9w=",
+			"path": "github.com/opencontainers/runc/libcontainer/keys",
+			"revision": "189a2ab2f7acc59043e457cea25b58f631443f08",
+			"revisionTime": "2016-08-27T03:18:55Z"
+		},
+		{
+			"checksumSHA1": "dU5yexe8VlfT61KD3znuL9qeL/A=",
+			"path": "github.com/opencontainers/runc/libcontainer/label",
+			"revision": "189a2ab2f7acc59043e457cea25b58f631443f08",
+			"revisionTime": "2016-08-27T03:18:55Z"
+		},
+		{
+			"checksumSHA1": "/9e4cNKDgYYJ2Rdq68nZDZy0vzM=",
+			"path": "github.com/opencontainers/runc/libcontainer/nsenter",
+			"revision": "189a2ab2f7acc59043e457cea25b58f631443f08",
+			"revisionTime": "2016-08-27T03:18:55Z"
+		},
+		{
+			"checksumSHA1": "RL5SI4xwxLKyA6XSU76BVTosC/8=",
+			"path": "github.com/opencontainers/runc/libcontainer/seccomp",
+			"revision": "189a2ab2f7acc59043e457cea25b58f631443f08",
+			"revisionTime": "2016-08-27T03:18:55Z"
+		},
+		{
+			"checksumSHA1": "Pkimgph9ZpCZPRDj2fM6CdTFJNE=",
+			"path": "github.com/opencontainers/runc/libcontainer/selinux",
+			"revision": "189a2ab2f7acc59043e457cea25b58f631443f08",
+			"revisionTime": "2016-08-27T03:18:55Z"
+		},
+		{
+			"checksumSHA1": "qVz/crWT90R+dOBdJI4tDqEaKiU=",
+			"path": "github.com/opencontainers/runc/libcontainer/specconv",
+			"revision": "189a2ab2f7acc59043e457cea25b58f631443f08",
+			"revisionTime": "2016-08-27T03:18:55Z"
+		},
+		{
+			"checksumSHA1": "yp/kYBgVqKtxlnpq4CmyxLFMAE4=",
+			"path": "github.com/opencontainers/runc/libcontainer/stacktrace",
+			"revision": "189a2ab2f7acc59043e457cea25b58f631443f08",
+			"revisionTime": "2016-08-27T03:18:55Z"
+		},
+		{
+			"checksumSHA1": "R93mnw63M+513kttRwG4YDp62oM=",
+			"path": "github.com/opencontainers/runc/libcontainer/system",
+			"revision": "189a2ab2f7acc59043e457cea25b58f631443f08",
+			"revisionTime": "2016-08-27T03:18:55Z"
+		},
+		{
+			"checksumSHA1": "3AoPMXlmVq2+iWMpsdJZkcUKHB8=",
+			"path": "github.com/opencontainers/runc/libcontainer/user",
+			"revision": "189a2ab2f7acc59043e457cea25b58f631443f08",
+			"revisionTime": "2016-08-27T03:18:55Z"
+		},
+		{
+			"checksumSHA1": "wCxd53xfZIkrpUhpCy7d02p5bUA=",
+			"path": "github.com/opencontainers/runc/libcontainer/utils",
+			"revision": "189a2ab2f7acc59043e457cea25b58f631443f08",
+			"revisionTime": "2016-08-27T03:18:55Z"
+		},
+		{
+			"checksumSHA1": "t8bcvgBOHdJLZsxTmVW6abGJjtc=",
+			"path": "github.com/opencontainers/runtime-spec/specs-go",
+			"revision": "90451c4923edfa8162425707c8a496085277267e",
+			"revisionTime": "2016-08-29T14:29:41Z"
+		},
+		{
+			"checksumSHA1": "m+Mj2Eh4hn2ihEWcqkZxuzjRqCY=",
+			"path": "github.com/seccomp/libseccomp-golang",
+			"revision": "32f571b70023028bd57d9288c20efbcb237f3ce0",
+			"revisionTime": "2016-05-30T16:56:11Z"
+		},
+		{
+			"checksumSHA1": "b7GCRCSXl4E7Ux0vOr3z9g3g5nE=",
+			"path": "github.com/syndtr/gocapability/capability",
+			"revision": "2c00daeb6c3b45114c80ac44119e7b8801fdd852",
+			"revisionTime": "2015-07-16T01:09:06Z"
+		},
+		{
 			"checksumSHA1": "jm802xmRmtkUSVCED5SiDwIe0Jo=",
 			"path": "github.com/urfave/cli",
 			"revision": "168c95418e66e019fe17b8f4f5c45aa62ff80e23",
@@ -153,10 +363,22 @@
 			"revisionTime": "2016-08-13T08:45:45Z"
 		},
 		{
+			"checksumSHA1": "zjfUA3qOv6grhBLpyJ+7EejXWQE=",
+			"path": "github.com/vishvananda/netns",
+			"revision": "8ba1072b58e0c2a240eb5f6120165c7776c3e7b8",
+			"revisionTime": "2016-04-30T05:37:23Z"
+		},
+		{
 			"checksumSHA1": "9jjO5GjLa0XF/nfWihF02RoH4qc=",
 			"path": "golang.org/x/net/context",
 			"revision": "07b51741c1d6423d4a6abab1c49940ec09cb1aaf",
 			"revisionTime": "2016-08-11T10:50:59Z"
+		},
+		{
+			"checksumSHA1": "LvdVRE0FqdR68SvVpRkHs1rxhcA=",
+			"path": "golang.org/x/net/proxy",
+			"revision": "6250b412798208e6c90b03b7c4f226de5aa299e2",
+			"revisionTime": "2016-08-24T22:20:41Z"
 		},
 		{
 			"checksumSHA1": "8fD/im5Kwvy3JgmxulDTambmE8w=",


### PR DESCRIPTION
PR for issue https://github.com/medallia/docker-routed-plugin/issues/2

Features added:
- Gateway address is passed to docker plugin on creation:

docker run -ti --privileged --net=host --rm -v /run/docker/plugins:/run/docker/plugins test/routed-plugin --gateway 10.0.2.15 --debug
- Gateway address is used to set default static route inside containers:

$ docker network create --internal --driver=net-routed --ipam-driver=ipam-routed --subnet 10.46.1.0/16 mine
$ docker run -ti --net=mine --ip 10.46.1.7 alpine sh
/ # ip r
default via 10.0.2.15 dev eth0 
10.0.2.15 dev eth0 

This results in an arp cache of only one entry for the containers:

/ # arp -a
? (10.0.2.15) at de:4b:46:17:22:02 [ether]  on eth0
